### PR TITLE
编写阿里云的实现

### DIFF
--- a/ALIYUN_IMPLEMENTATION_SUMMARY.md
+++ b/ALIYUN_IMPLEMENTATION_SUMMARY.md
@@ -1,0 +1,141 @@
+# 阿里云DNS服务实现总结
+
+## 完成的工作
+
+### 1. 添加依赖
+在 `pom.xml` 中添加了阿里云DNS SDK依赖：
+```xml
+<dependency>
+    <groupId>com.aliyun</groupId>
+    <artifactId>aliyun-java-sdk-core</artifactId>
+    <version>4.6.4</version>
+</dependency>
+<dependency>
+    <groupId>com.aliyun</groupId>
+    <artifactId>aliyun-java-sdk-alidns</artifactId>
+    <version>3.0.22</version>
+</dependency>
+```
+
+### 2. 创建阿里云DNS服务实现
+创建了 `AliyunDDNSServiceImpl` 类，实现了 `DDNSService` 接口，包含以下功能：
+
+#### 核心功能
+- **初始化客户端**: 使用AccessKey和SecretKey创建阿里云DNS客户端
+- **配置验证**: 验证必要的配置参数
+- **连接测试**: 启动时测试API连接是否正常
+- **DNS记录更新**: 支持创建和更新DNS记录
+- **当前记录查询**: 获取现有DNS记录值
+
+#### 主要方法
+- `updateDNSRecord()`: 更新DNS记录（自动判断是创建新记录还是更新现有记录）
+- `getCurrentRecord()`: 获取当前DNS记录值
+- `validateConfig()`: 验证配置参数
+- `testConnection()`: 测试API连接
+
+#### 使用的阿里云API
+- `DescribeDomainsRequest`: 域名列表查询（用于连接测试）
+- `DescribeDomainRecordsRequest`: 域名记录查询
+- `AddDomainRecordRequest`: 添加新的DNS记录
+- `UpdateDomainRecordRequest`: 更新现有DNS记录
+
+### 3. 更新工厂类
+在 `DDNSFactory` 类中添加了阿里云服务的支持：
+- 添加 `AliyunDDNSServiceImpl` 依赖注入
+- 在 `createDDNSService()` 方法中添加阿里云分支处理
+
+### 4. 配置文件支持
+项目已完整支持阿里云配置：
+
+#### application.yml 配置示例
+```yaml
+spring:
+  config:
+    activate:
+      on-profile: aliyun
+ddns:
+  provider: aliyun
+  access-key: ${DDNS_ACCESS_KEY:your_aliyun_access_key}
+  secret-key: ${DDNS_SECRET_KEY:your_aliyun_secret_key}
+  domain: ${DDNS_DOMAIN:your_domian}
+  sub-domain: ${DDNS_SUB_DOMAIN:your_sub_domain}
+```
+
+#### Docker配置示例
+docker-compose.yml 中已包含阿里云配置示例：
+```yaml
+# 阿里云配置
+# - DDNS_ACCESS_KEY=your_aliyun_access_key
+# - DDNS_SECRET_KEY=your_aliyun_secret_key
+# - DDNS_DOMAIN=example.com
+# - DDNS_SUB_DOMAIN=home
+```
+
+### 5. 文档更新
+README.md 文档已包含阿里云DNS的完整说明：
+- 支持的DNS服务提供商列表中包含阿里云
+- 阿里云配置说明和示例
+- 使用方法和注意事项
+
+## 实现特点
+
+### 1. 与现有架构完全兼容
+- 遵循现有的设计模式和接口规范
+- 与腾讯云和Cloudflare实现保持一致的结构
+- 支持环境变量和配置文件两种配置方式
+
+### 2. 完善的错误处理
+- 配置验证和错误提示
+- API调用异常处理
+- 详细的日志记录
+
+### 3. 功能完整性
+- 支持DNS记录的查询、创建和更新
+- 自动判断记录是否存在，选择合适的操作
+- 支持A记录类型（可扩展支持其他类型）
+- 配置TTL为600秒（10分钟）
+
+### 4. 安全性考虑
+- AccessKey日志脱敏显示
+- 敏感信息不在日志中完整显示
+
+## 使用方法
+
+### 1. 配置阿里云API凭证
+在阿里云控制台获取AccessKey ID和AccessKey Secret
+
+### 2. 配置环境变量或配置文件
+```bash
+export SPRING_PROFILES_ACTIVE=aliyun
+export DDNS_ACCESS_KEY=your_aliyun_access_key_id
+export DDNS_SECRET_KEY=your_aliyun_access_key_secret
+export DDNS_DOMAIN=example.com
+export DDNS_SUB_DOMAIN=home
+```
+
+### 3. 启动应用
+```bash
+java -jar auto-ddns-1.0.0.jar
+```
+
+应用将自动使用阿里云DNS服务进行域名解析记录的动态更新。
+
+## 验证方法
+
+启动后可在日志中看到以下信息来验证阿里云服务是否正常：
+```
+阿里云DNS服务初始化成功
+AccessKey: LTAI***W8nV, SecretKey长度: 30
+DNS服务连接测试成功
+```
+
+如果配置错误，会看到相应的错误提示。
+
+## 总结
+
+阿里云DNS服务实现已完成并集成到项目中，现在项目支持三个主要的DNS服务提供商：
+1. 腾讯云DNS (DNSPod)
+2. 阿里云DNS
+3. Cloudflare DNS
+
+用户可以通过配置 `ddns.provider=aliyun` 来使用阿里云DNS服务。

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,16 @@
             <version>3.1.1172</version>
         </dependency>
         <dependency>
+            <groupId>com.aliyun</groupId>
+            <artifactId>aliyun-java-sdk-core</artifactId>
+            <version>4.6.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.aliyun</groupId>
+            <artifactId>aliyun-java-sdk-alidns</artifactId>
+            <version>3.0.22</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>

--- a/src/main/java/com/qin/autoddns/factory/DDNSFactory.java
+++ b/src/main/java/com/qin/autoddns/factory/DDNSFactory.java
@@ -2,6 +2,7 @@ package com.qin.autoddns.factory;
 
 import com.qin.autoddns.enums.DNSProvider;
 import com.qin.autoddns.service.DDNSService;
+import com.qin.autoddns.service.impl.AliyunDDNSServiceImpl;
 import com.qin.autoddns.service.impl.CloudflareDDNSServiceImpl;
 import com.qin.autoddns.service.impl.TencentDDNSServiceImpl;
 import org.springframework.stereotype.Component;
@@ -11,11 +12,14 @@ public class DDNSFactory {
 
     private final TencentDDNSServiceImpl tencentDDNSService;
     private final CloudflareDDNSServiceImpl cloudflareDDNSService;
+    private final AliyunDDNSServiceImpl aliyunDDNSService;
 
     public DDNSFactory(TencentDDNSServiceImpl tencentDDNSService,
-                       CloudflareDDNSServiceImpl cloudflareDDNSService) {
+                       CloudflareDDNSServiceImpl cloudflareDDNSService,
+                       AliyunDDNSServiceImpl aliyunDDNSService) {
         this.tencentDDNSService = tencentDDNSService;
         this.cloudflareDDNSService = cloudflareDDNSService;
+        this.aliyunDDNSService = aliyunDDNSService;
     }
 
     public DDNSService createDDNSService(String type) {
@@ -23,8 +27,7 @@ public class DDNSFactory {
         return switch (provider) {
             case TENCENT -> tencentDDNSService;
             case CLOUDFLARE -> cloudflareDDNSService;
-            case ALIYUN ->
-                    throw new UnsupportedOperationException(provider.getDesc() + " DNS service not implemented yet");
+            case ALIYUN -> aliyunDDNSService;
         };
     }
 } 

--- a/src/main/java/com/qin/autoddns/service/impl/AliyunDDNSServiceImpl.java
+++ b/src/main/java/com/qin/autoddns/service/impl/AliyunDDNSServiceImpl.java
@@ -1,0 +1,202 @@
+package com.qin.autoddns.service.impl;
+
+import com.aliyuncs.DefaultAcsClient;
+import com.aliyuncs.IAcsClient;
+import com.aliyuncs.alidns.model.v20150109.DescribeDomainsRequest;
+import com.aliyuncs.alidns.model.v20150109.DescribeDomainsResponse;
+import com.aliyuncs.alidns.model.v20150109.DescribeDomainRecordsRequest;
+import com.aliyuncs.alidns.model.v20150109.DescribeDomainRecordsResponse;
+import com.aliyuncs.alidns.model.v20150109.UpdateDomainRecordRequest;
+import com.aliyuncs.alidns.model.v20150109.UpdateDomainRecordResponse;
+import com.aliyuncs.alidns.model.v20150109.AddDomainRecordRequest;
+import com.aliyuncs.alidns.model.v20150109.AddDomainRecordResponse;
+import com.aliyuncs.exceptions.ClientException;
+import com.aliyuncs.profile.DefaultProfile;
+import com.qin.autoddns.config.DDNSConfig;
+import com.qin.autoddns.service.DDNSService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+/**
+ * 阿里云DNS服务实现
+ *
+ * @author qinshijiao
+ * @since 2024/03/21
+ */
+@Service
+public class AliyunDDNSServiceImpl implements DDNSService {
+
+    private final Logger log = LoggerFactory.getLogger(AliyunDDNSServiceImpl.class);
+    private IAcsClient client;
+    private final DDNSConfig config;
+    private final Environment environment;
+
+    public AliyunDDNSServiceImpl(DDNSConfig config, Environment environment) {
+        this.config = config;
+        this.environment = environment;
+
+        // 检查是否激活了阿里云配置
+        String[] activeProfiles = environment.getActiveProfiles();
+        boolean isAliyunProfileActive = activeProfiles.length == 0 ||
+                environment.getProperty("ddns.provider", String.class, "").equals("aliyun");
+
+        if (isAliyunProfileActive) {
+            try {
+                // 验证配置
+                validateConfig();
+
+                // 初始化客户端
+                DefaultProfile profile = DefaultProfile.getProfile("cn-hangzhou", 
+                    config.getAccessKey(), config.getSecretKey());
+                this.client = new DefaultAcsClient(profile);
+
+                // 测试连接
+                testConnection();
+
+                log.info("阿里云DNS服务初始化成功");
+            } catch (Exception e) {
+                log.error("阿里云DNS服务初始化失败: {}", e.getMessage());
+                throw new RuntimeException("DNS服务初始化失败", e);
+            }
+        } else {
+            log.info("阿里云DNS服务未激活，跳过初始化");
+        }
+    }
+
+    private void validateConfig() {
+        if (config.getAccessKey() == null || config.getAccessKey().trim().isEmpty()) {
+            throw new IllegalArgumentException("AccessKey 不能为空");
+        }
+        if (config.getSecretKey() == null || config.getSecretKey().trim().isEmpty()) {
+            throw new IllegalArgumentException("SecretKey 不能为空");
+        }
+        log.info("AccessKey: {}, SecretKey长度: {}",
+                maskAccessKey(config.getAccessKey()),
+                config.getSecretKey().length());
+    }
+
+    private String maskAccessKey(String accessKey) {
+        if (accessKey == null || accessKey.length() < 8) {
+            return "***";
+        }
+        return accessKey.substring(0, 4) + "***" + accessKey.substring(accessKey.length() - 4);
+    }
+
+    private void testConnection() {
+        try {
+            DescribeDomainsRequest request = new DescribeDomainsRequest();
+            request.setPageSize(1);
+            client.getAcsResponse(request);
+            log.info("DNS服务连接测试成功");
+        } catch (ClientException e) {
+            log.error("DNS服务连接测试失败: {}", e.getMessage());
+            throw new RuntimeException("DNS服务连接测试失败", e);
+        }
+    }
+
+    @Override
+    public boolean updateDNSRecord(String domain, String subDomain, String recordType, String value) {
+        if (client == null) {
+            log.warn("阿里云DNS服务未初始化，无法更新记录");
+            return false;
+        }
+
+        try {
+            log.info("开始更新DNS记录: domain={}, subDomain={}, type={}, value={}",
+                    domain, subDomain, recordType, value);
+
+            String recordId = getRecordId(domain, subDomain, recordType);
+            if (recordId != null) {
+                return updateExistingRecord(recordId, subDomain, recordType, value);
+            } else {
+                return createNewRecord(domain, subDomain, recordType, value);
+            }
+        } catch (ClientException e) {
+            log.error("更新DNS记录失败: {}", e.getMessage(), e);
+            return false;
+        }
+    }
+
+    private boolean updateExistingRecord(String recordId, String subDomain, String recordType, String value) 
+            throws ClientException {
+        log.info("更新已存在的记录: recordId={}", recordId);
+        UpdateDomainRecordRequest request = new UpdateDomainRecordRequest();
+        request.setRecordId(recordId);
+        request.setRR(subDomain);
+        request.setType(recordType);
+        request.setValue(value);
+        request.setTTL(600L); // 默认TTL 600秒
+
+        UpdateDomainRecordResponse response = client.getAcsResponse(request);
+        log.info("记录更新成功: {}", response.getRecordId());
+        return true;
+    }
+
+    private boolean createNewRecord(String domain, String subDomain, String recordType, String value) 
+            throws ClientException {
+        log.info("创建新记录");
+        AddDomainRecordRequest request = new AddDomainRecordRequest();
+        request.setDomainName(domain);
+        request.setRR(subDomain);
+        request.setType(recordType);
+        request.setValue(value);
+        request.setTTL(600L); // 默认TTL 600秒
+
+        AddDomainRecordResponse response = client.getAcsResponse(request);
+        log.info("新记录创建成功: {}", response.getRecordId());
+        return true;
+    }
+
+    @Override
+    public String getCurrentRecord(String domain, String subDomain) {
+        if (client == null) {
+            log.warn("阿里云DNS服务未初始化，无法获取记录");
+            return null;
+        }
+
+        try {
+            log.debug("获取当前记录: domain={}, subDomain={}", domain, subDomain);
+            DescribeDomainRecordsRequest request = new DescribeDomainRecordsRequest();
+            request.setDomainName(domain);
+            request.setRRKeyWord(subDomain);
+
+            DescribeDomainRecordsResponse response = client.getAcsResponse(request);
+            if (response.getDomainRecords() != null && !response.getDomainRecords().isEmpty()) {
+                for (DescribeDomainRecordsResponse.Record record : response.getDomainRecords()) {
+                    if (record.getRR().equals(subDomain)) {
+                        log.debug("找到记录: {}", record.getValue());
+                        return record.getValue();
+                    }
+                }
+            }
+            log.debug("未找到记录");
+            return null;
+        } catch (ClientException e) {
+            log.error("获取当前记录失败: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private String getRecordId(String domain, String subDomain, String recordType) {
+        try {
+            DescribeDomainRecordsRequest request = new DescribeDomainRecordsRequest();
+            request.setDomainName(domain);
+            request.setRRKeyWord(subDomain);
+            request.setType(recordType);
+
+            DescribeDomainRecordsResponse response = client.getAcsResponse(request);
+            if (response.getDomainRecords() != null && !response.getDomainRecords().isEmpty()) {
+                for (DescribeDomainRecordsResponse.Record record : response.getDomainRecords()) {
+                    if (record.getRR().equals(subDomain) && record.getType().equals(recordType)) {
+                        return record.getRecordId();
+                    }
+                }
+            }
+        } catch (ClientException e) {
+            log.error("获取记录ID失败: {}", e.getMessage(), e);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Add Alibaba Cloud DNS service implementation to support a new DNS provider.
The project previously supported Tencent Cloud and Cloudflare; this PR extends dynamic DNS update capabilities to include Alibaba Cloud DNS, offering users more flexibility.